### PR TITLE
Fix incorrect filter usage

### DIFF
--- a/docs/auditor-bundle/usage/querying.md
+++ b/docs/auditor-bundle/usage/querying.md
@@ -55,10 +55,12 @@ $query = $reader->createQuery(Author::class, [
     'object_id' => 5,
 ]);
 
-// the above code could also be written like this 
+// the above code could also be written like this
+use \DH\Auditor\Provider\Doctrine\Persistence\Reader\Filter\SimpleFilter;
+
 $query = $reader
     ->createQuery(Author::class)
-    ->addFilter(new \DH\Auditor\Provider\Doctrine\Persistence\Reader\Filter\SimpleFilter(Query::OBJECT_ID, 5));
+    ->addFilter(new SimpleFilter(Query::OBJECT_ID, 5));
 ;
 ```
 

--- a/docs/auditor-bundle/usage/querying.md
+++ b/docs/auditor-bundle/usage/querying.md
@@ -58,7 +58,7 @@ $query = $reader->createQuery(Author::class, [
 // the above code could also be written like this 
 $query = $reader
     ->createQuery(Author::class)
-    ->addFilter(Query::OBJECT_ID, 5);
+    ->addFilter(new \DH\Auditor\Provider\Doctrine\Persistence\Reader\Filter\SimpleFilter(Query::OBJECT_ID, 5));
 ;
 ```
 


### PR DESCRIPTION
Docs and the code diverged in https://github.com/DamienHarper/auditor/commit/60311b8df20fa152dfb057762de2e50bac85fe06#diff-4ba21697125a3b656cc78ce0c08bc400c53f5cc4e4dd4a8e1a241a1904393842R100

FQDN used to avoid having to `use` the class at the top as the code example is just a code snippet, not a full PHP file. I'm 50/50 undecided which approach is better:

```php
$reader = new Reader($provider);

// creates a query on Author audits with a filter on the object ID
// audits of the author which ID is not 5 will be filtered out. 
$query = $reader->createQuery(Author::class, [
    'object_id' => 5,
]);

// the above code could also be written like this 
$query = $reader
    ->createQuery(Author::class)
    ->addFilter(new \DH\Auditor\Provider\Doctrine\Persistence\Reader\Filter\SimpleFilter(Query::OBJECT_ID, 5));
;
```

or

```php
$reader = new Reader($provider);

// creates a query on Author audits with a filter on the object ID
// audits of the author which ID is not 5 will be filtered out. 
$query = $reader->createQuery(Author::class, [
    'object_id' => 5,
]);

// the above code could also be written like this 
use \DH\Auditor\Provider\Doctrine\Persistence\Reader\Filter\SimpleFilter;
$query = $reader
    ->createQuery(Author::class)
    ->addFilter(new SimpleFilter(Query::OBJECT_ID, 5));
;
```