### PR TITLE
Install damienharper/auditor to copy `tests` folder

### DIFF
--- a/docs/auditor-bundle/contributing.md
+++ b/docs/auditor-bundle/contributing.md
@@ -23,6 +23,7 @@ composer install --dev
 You also have to install external dev tools:
 
 ```bash
+composer reinstall damienharper/auditor --prefer-install=source
 composer install --working-dir=tools/php-cs-fixer
 composer install --working-dir=tools/phpstan
 ```


### PR DESCRIPTION
Since https://github.com/DamienHarper/auditor-bundle/pull/326 merged, while running tests in `auditor-bundle` some dependencies not exists, because it uses `auditor-bundle/tests` folder
The PR adds doc to install it